### PR TITLE
Add new deps in 2025

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ cabalver = 3.12.1.0
 ghcup_apt_dependency = build-essential curl libffi-dev libffi8ubuntu1 \
 	libgmp-dev libgmp10 libncurses-dev libncurses6 libtinfo6 llvm-15
 
+hmatrix_apt_dependency = libgsl0-dev liblapack-dev libatlas-base-dev libglpk-dev
+
 # default username for docker images. THIS CANNOT BE root.
 ghcup_user = runner
 
@@ -215,6 +217,7 @@ dist/installsteps/install.sh: \
 	-e 's/REPLACE_GHCVER/$(ghcver)/' \
 	-e 's/REPLACE_CABALVER/$(cabalver)/' \
 	-e 's/REPLACE_GHCUP_APT_DEPENDENCY/$(ghcup_apt_dependency)/' \
+	-e 's/REPLACE_HMATRIX_APT_DEPENDENCY/$(hmatrix_apt_dependency)/' \
 	src/installsteps/install.sh.template \
 	> dist/installsteps/install.sh
 

--- a/src/installsteps/install.sh.template
+++ b/src/installsteps/install.sh.template
@@ -8,6 +8,8 @@ sudo apt-get install -y --no-install-recommends REPLACE_GHCUP_APT_DEPENDENCY
 curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | BOOTSTRAP_HASKELL_NONINTERACTIVE=1 BOOTSTRAP_HASKELL_GHC_VERSION=REPLACE_GHCVER BOOTSTRAP_HASKELL_CABAL_VERSION=REPLACE_CABALVER BOOTSTRAP_HASKELL_INSTALL_NO_STACK=1 sh
 source ~/.ghcup/env
 
+RUN apt-get install -y --no-install-recommends REPLACE_HMATRIX_APT_DEPENDENCY
+
 mkdir -p submission/app
 
 cd submission

--- a/src/serverproto/Dockerfile
+++ b/src/serverproto/Dockerfile
@@ -5,6 +5,12 @@ ARG DEFAULT_MAIN_FILE="HelloHaskell.hs"
 ARG CABAL_FILE="submission.cabal"
 ARG PROJ_FILE="cabal.project"
 ARG USERNAME="runner"
+ARG HMATRIX_APT_DEPENDENCY="libgsl0-dev liblapack-dev libatlas-base-dev libglpk-dev"
+
+USER root
+RUN apt-get install -y --no-install-recommends $HMATRIX_APT_DEPENDENCY
+
+USER $USERNAME
 WORKDIR submission/app
 COPY --chown=${USERNAME}:${USERNAME} ${DEFAULT_MAIN_FILE} ./Main.hs
 WORKDIR ..

--- a/src/serverproto/dependencies
+++ b/src/serverproto/dependencies
@@ -26,6 +26,10 @@ ghc-boot-th ==9.8.4
 ghc-prim ==0.11.0
 hashable ^>=1.5.0.0
 heaps ^>=0.4.1
+hmatrix ^>=0.20.2
+hmatrix-glpk ^>=0.19.0.0
+hmatrix-gsl ^>=0.19.0.1
+hmatrix-special ^>=0.19.0.0
 ilist ^>=0.4.0.1
 indexed-traversable ^>=0.1.4
 indexed-traversable-instances ^>=0.1.2

--- a/src/serverproto/dependencies
+++ b/src/serverproto/dependencies
@@ -1,6 +1,7 @@
 Cabal ^>=3.14.1.1
 Cabal-syntax ^>=3.14.1.0
 QuickCheck ^>=2.15.0.1
+ac-library-hs ^>=1.1.0.0
 adjunctions ^>=4.4.2
 array ==0.5.8.0
 attoparsec ^>=0.14.4
@@ -25,6 +26,7 @@ ghc-boot-th ==9.8.4
 ghc-prim ==0.11.0
 hashable ^>=1.5.0.0
 heaps ^>=0.4.1
+ilist ^>=0.4.0.1
 indexed-traversable ^>=0.1.4
 indexed-traversable-instances ^>=0.1.2
 integer-gmp ^>=1.1
@@ -35,6 +37,7 @@ linear-base ^>=0.4.0
 list-t ^>=1.0.5.7
 massiv ^>=1.0.4.1
 megaparsec ^>=9.7.0
+monad-memo ^>=0.5.4
 mono-traversable ^>=1.0.21.0
 mtl ^>=2.3.1
 mutable-containers ^>=0.3.4.1
@@ -73,6 +76,9 @@ unordered-containers ^>=0.2.20
 utility-ht ^>=0.0.17.2
 vector ^>=0.13.2.0
 vector-algorithms ^>=0.9.0.3
+vector-split ^>=1.0.0.3
 vector-stream ^>=0.1.0.1
 vector-th-unbox ^>=0.2.2
+wide-word ^>=0.1.6.0
+witherable ^>=0.5
 xhtml ^>=3000.2.2.1


### PR DESCRIPTION
Here we go~

Edit: Sorry I missed package descriptions.

- `ac-library-hs` ([GitHub](https://github.com/toyboot4e/ac-library-hs), [Hackage](https://hackage.haskell.org/package/ac-library-hs))
- `ilist` ([GitHub](https://github.com/brandonhamilton/ilist), [Hackage](https://hackage.haskell.org/package/ilist))
- `monad-memo` ([GitHub](https://github.com/EduardSergeev/monad-memo), [Hackage](https://hackage.haskell.org/package/monad-memo))
- `vector-split` ([GitHub](https://github.com/fhaust/vector-split), [Hackage](https://hackage.haskell.org/package/vector-split))
- `wide-word` ([GitHub](https://github.com/erikd/wide-word), [Hackage](https://hackage.haskell.org/package/wide-word))
- `witherable` ([GitHub](https://github.com/fumieval/witherable), [Hackage](https://hackage.haskell.org/package/witherable))

`hmatrix` requires additional `apt` dependencies, as described in [`INSTALL.md`](https://github.com/haskell-numerics/hmatrix/blob/master/INSTALL.md).

- `hmatrix` ([GitHub](https://github.com/haskell-numerics/hmatrix), [Hackage](https://hackage.haskell.org/package/hmatrix))
- `hmatrix-glpk` ([Hackage](https://hackage.haskell.org/package/hmatrix-glpk))
- `hmatrix-gsl` ([Hackage](https://hackage.haskell.org/package/hmatrix-gsl))
- `hmatrix-special` ([Hackage](https://hackage.haskell.org/package/hmatrix-special))

There are [some other `hmatrix-*` libraries as searched in Hackage](https://hackage.haskell.org/packages/search?terms=hmatrix). I didn't look into them (yet).
