### PR TITLE
Update dependency versions

### DIFF
--- a/src/serverproto/dependencies
+++ b/src/serverproto/dependencies
@@ -1,7 +1,7 @@
 Cabal ^>=3.14.2.0
 Cabal-syntax ^>=3.14.2.0
 QuickCheck ^>=2.15.0.1
-ac-library-hs ^>=1.3.0.0
+ac-library-hs ^>=1.4.0.0
 adjunctions ^>=4.4.3
 array ==0.5.8.0
 attoparsec ^>=0.14.4


### PR DESCRIPTION
It just updates `ac-library-hs` to `1.4.0.0`.

`installscript.toml` will be updated as this commit: https://github.com/toyboot4e/haskell-install-script-test-2025/commit/4236ea3c84844675a8a2f8c7b5728dffc645ae3d.
